### PR TITLE
Example test case for connections not being released

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,8 +104,14 @@ export default (conString) => {
       .resolve()
       .then(fn)
       .then(
-        (res) => unlock().then(() => res),
-        (err) => unlock().then(() => { throw err })
+        (res) => unlock().then(() => {
+          client.end()
+          return res
+        }),
+        (err) => unlock().then(() => {
+          client.end()
+          throw err
+        })
       )
     )
 

--- a/test/index.js
+++ b/test/index.js
@@ -183,19 +183,15 @@ test('withLock releases connection after unlocking', (t) => {
     advisoryLock(conString)('test-withlock-release')
   )
 
-  for (let i = 0; i < 50; i++) {
-    getMutex().withLock().then(() => {
-      getActiveConnections().then((conns) => {
-        console.log(conns)
+  getActiveConnections().then((startConnectionCount) => {
+    for (let i = 0; i < 25; i++) {
+      getMutex().withLock().catch(t.fail)
+    }
+    timeout(500).then(() => {
+      getActiveConnections().then((connectionCount) => {
+        t.equal(connectionCount, startConnectionCount)
+        t.end()
       })
-    }).catch(t.fail)
-  }
-
-  timeout(30000).then(() => {
-    getActiveConnections().then((conns) => {
-      console.log('=-=-=-=-=-=-=-')
-      console.log(conns)
-      t.end()
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+import pg from 'pg'
 import test from 'tape'
 
 import advisoryLock, { strToKey } from '../src'
@@ -6,6 +7,20 @@ const conString = process.env.PG_CONNECTION_STRING
   || 'postgres://postgres@192.168.99.100/advisorylock'
 
 const timeout = (ms = 300) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Returns the number of active connections to the database
+const getActiveConnections = () => new Promise((resolve, reject) => {
+  const sql = 'SELECT count(*) FROM pg_stat_activity'
+  const client = new pg.Client(conString)
+  client.connect((connectError) => {
+    if (connectError) return reject(connectError)
+    client.query(sql, (queryError, result) => {
+      if (queryError) return reject(queryError)
+      resolve(Number(result.rows[0].count))
+      client.end()
+    })
+  })
+})
 
 test('strToKey', (t) => {
   const key = strToKey('test-lock')
@@ -162,5 +177,28 @@ test('withLock blocks until lock available', (t) => {
     .then(maybeDone)
     .catch(t.fail)
 })
+
+test('withLock releases connection after unlocking', (t) => {
+  const getMutex = () => (
+    advisoryLock(conString)('test-withlock-release')
+  )
+
+  for (let i = 0; i < 50; i++) {
+    getMutex().withLock().then(() => {
+      getActiveConnections().then((conns) => {
+        console.log(conns)
+      })
+    }).catch(t.fail)
+  }
+
+  timeout(30000).then(() => {
+    getActiveConnections().then((conns) => {
+      console.log('=-=-=-=-=-=-=-')
+      console.log(conns)
+      t.end()
+    })
+  })
+})
+
 
 // TODO: test thowing inside critical section unlocks mutex


### PR DESCRIPTION
This is a work in progress. Do not merge.

I added a test case which exemplifies the issue I'm running into.

It uses `withLock()` in a tight loop and prints the number of active database connections to console.

Notice how the number of connections jumps up but then when the print statement is run after a 30 second timeout, the number of connections has not decreased.

An example of what I see:

```
68
69
69
70
74
75
74
75
75
78
78
80
80
81
84
88
92
74
92
92
92
91
94
94
94
94
94
92
87
86
87
87
87
87
90
90
90
90
94
85
83
78
76
76
76
73
73
70
66
66


=-=-=-=-=-=-=-
64
```

The last line is printed after a 30 second delay.

However, if I make the following change to this line: https://github.com/blockai/advisory-lock/blob/master/src/index.js#L103

```
    const withLock = (fn) => lock().then(() => Promise
      .resolve()
      .then(fn)
      .then(
        (res) => unlock().then(() => {
          client.end() // Add this
          return res
        }),
        (err) => unlock().then(() => {
          client.end() // Add this
          throw err
        })
      )
    )
```

The connections are closed as the locks are released and the connection count consistently drops back down.

Normally I'd open a pull request with a simple failing test and a fix but I'm finding it difficult to create a consistent unit test for this issue.
